### PR TITLE
Add @mongodb-js/dbx-devtools as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code owners for this repository
+* @mongodb-js/dbx-devtools


### PR DESCRIPTION
This PR adds @mongodb-js/dbx-devtools as codeowner for the entire repository.